### PR TITLE
Fix Frends.Tasks.Attributes reference to a working version (1.2.1)

### DIFF
--- a/Frends.Csv/Frends.Csv.csproj
+++ b/Frends.Csv/Frends.Csv.csproj
@@ -36,8 +36,7 @@
       <HintPath>..\packages\CsvHelper.2.16.3.0\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
     <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.0\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Frends.Csv/packages.config
+++ b/Frends.Csv/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="2.16.3.0" targetFramework="net452" />
-  <package id="Frends.Tasks.Attributes" version="1.2.0" targetFramework="net452" />
+  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -3,16 +3,10 @@
    - [Building](#building)
    - [Contributing](#contributing)
    - [Documentation](#documentation)
-     - [Csv.Parse](#csv.parse)
-       - [Input](#input)
-         - [ColumnSpecification](#columnspecification)
-       - [Options](#options)
-       - [Example usage](#example-usage)
-       - [Result](#result)
-     - [Csv.Create](#csv.create)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
+     - [Csv.Parse](#csvparse)
+         - [ColumnSpecification](#columnspecification) 
+       - [Example usage](#example-usage) 
+     - [Csv.Create](#csvcreate)
    - [License](#license)
           
 # Frends.Csv
@@ -23,8 +17,6 @@ You can install the task via FRENDS UI Task View or you can find the nuget packa
 `https://www.myget.org/F/frends/api/v2`
 
 ## Building
-Ensure that you have `https://www.myget.org/F/frends/api/v2` added to your nuget feeds
-
 Clone a copy of the repo
 
 `git clone https://github.com/FrendsPlatform/Frends.Csv.git`

--- a/nuspec/Frends.Csv.nuspec
+++ b/nuspec/Frends.Csv.nuspec
@@ -10,7 +10,6 @@
     <description>FRENDS Csv tasks</description>
     <summary />
     <dependencies>
-	    <dependency id="Frends.Tasks.Attributes" version="1.2.0" />
       <dependency id="Newtonsoft.Json" version="6.0.8" />
       <dependency id="CsvHelper" version="[2.16.3.0]" />
     </dependencies>


### PR DESCRIPTION
Version 1.2.0 cannot be used as it has the wrong assembly version, so compilation will fail.