### PR TITLE
Replaced Frends.tasks.attributes with System.ComponentModel.DataAnnotations

### DIFF
--- a/Frends.Csv/Csv.cs
+++ b/Frends.Csv/Csv.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using CsvHelper;
 using CsvHelper.Configuration;
-using Frends.Tasks.Attributes;
 using Newtonsoft.Json;
 
 #pragma warning disable 1591
@@ -18,7 +18,7 @@ namespace Frends.Csv
         /// Parse string csv content to a object. See https://github.com/FrendsPlatform/Frends.Csv
         /// </summary>
         /// <returns>Object { List&lt;List&lt;object&gt;&gt; Data, List&lt;string&gt; Headers, JToken ToJson(), string ToXml() } </returns>
-        public static ParseResult Parse([CustomDisplay(DisplayOption.Tab)] ParseInput input, [CustomDisplay(DisplayOption.Tab)] ParseOption option)
+        public static ParseResult Parse([PropertyTab] ParseInput input, [PropertyTab] ParseOption option)
         {
             var configuration = new CsvConfiguration
             {
@@ -113,7 +113,7 @@ namespace Frends.Csv
         /// Create a csv string from object or from a json string. See https://github.com/FrendsPlatform/Frends.Csv
         /// </summary>
         /// <returns>Object { string Csv } </returns>
-        public static CreateResult Create([CustomDisplay(DisplayOption.Tab)] CreateInput input, [CustomDisplay(DisplayOption.Tab)] CreateOption option)
+        public static CreateResult Create([PropertyTab] CreateInput input, [PropertyTab] CreateOption option)
         {
             var config = new CsvConfiguration()
             {

--- a/Frends.Csv/Definitions.cs
+++ b/Frends.Csv/Definitions.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Xml;
-using Frends.Tasks.Attributes;
 using Newtonsoft.Json.Linq;
 using Formatting = Newtonsoft.Json.Formatting;
 
@@ -27,21 +27,21 @@ namespace Frends.Csv
         /// Json string to write to CSV. Must be an array of objects
         /// </summary>
         [DefaultValue("[{\"Column1\": \"row1Val1\",\"Column2\": \"row1Val2\"},{\"Column1\": \"row2Val1\",\"Column2\": \"row2Val2\"}]")]
-        [ConditionalDisplay(nameof(InputType), CreateInputType.Json)]
-        [DefaultDisplayType(DisplayType.Json)]
+        [UIHint(nameof(InputType), "", CreateInputType.Json)]
+        [DisplayFormat(DataFormatString = "Json")]
         public string Json { get; set; }
 
         /// <summary>
         /// Headers for the data. Need to be in the same order as the underlying data
         /// </summary>
-        [ConditionalDisplay(nameof(InputType), CreateInputType.List)]
+        [UIHint(nameof(InputType), "", CreateInputType.List)]
         public List<string> Headers { get; set; }
 
         /// <summary>
         /// Data to write to the csv string. Needs to be of type List&lt;List&lt;object&gt;&gt;. The order of the nested list objects need to be in the same order as the header list.
         /// </summary>
-        [ConditionalDisplay(nameof(InputType),CreateInputType.List)]
-        [DefaultDisplayType(DisplayType.Expression)]
+        [UIHint(nameof(InputType), "", CreateInputType.List)]
+        [DisplayFormat(DataFormatString = "Expression")]
         public List<List<object>> Data { get; set; }
 
         [DefaultValue("\";\"")]
@@ -77,7 +77,7 @@ namespace Frends.Csv
         /// <summary>
         /// Input csv string
         /// </summary>
-        [DefaultDisplayType(DisplayType.MultilineText)]
+        [DisplayFormat(DataFormatString = "Text")]
         public string Csv { get; set; }
 
         /// <summary>

--- a/Frends.Csv/Frends.Csv.csproj
+++ b/Frends.Csv/Frends.Csv.csproj
@@ -35,14 +35,12 @@
     <Reference Include="CsvHelper, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\packages\CsvHelper.2.16.3.0\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
-    <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/Frends.Csv/packages.config
+++ b/Frends.Csv/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="2.16.3.0" targetFramework="net452" />
-  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Replaced usage of custom attributes from Frends.tasks.attributes with their counterparts from System.ComponentModel.DataAnnotations, as the Frends.Tasks.Attributes reference mostly does not work together with older versions