### PR TITLE
Issue#8: When input is json, numbers and datetimes no longer get refo…

### DIFF
--- a/Frends.Csv.Tests/Frends.Csv.Tests.csproj
+++ b/Frends.Csv.Tests/Frends.Csv.Tests.csproj
@@ -39,9 +39,8 @@
       <HintPath>..\packages\CsvHelper.2.16.3.0\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>

--- a/Frends.Csv.Tests/Frends.Csv.Tests.csproj
+++ b/Frends.Csv.Tests/Frends.Csv.Tests.csproj
@@ -39,8 +39,8 @@
       <HintPath>..\packages\CsvHelper.2.16.3.0\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>

--- a/Frends.Csv.Tests/Tests.cs
+++ b/Frends.Csv.Tests/Tests.cs
@@ -174,6 +174,7 @@ Is.EqualTo(
 "));
         }
 
+
         [Test]
         public void TestWriteFromJson()
         {
@@ -187,7 +188,65 @@ maybe;never
 "));
         }
 
+        [Test]
+        public void TestNullInputValue()
+        {
+            var json = @"[{""ShouldStayNull"":""null"", ""ShouldBeReplaced"": null}]";
+            var result = Csv.Create(new CreateInput() { InputType = CreateInputType.Json, Delimiter = ";", Json = json }, new CreateOption() { ReplaceNullsWith = "replacedvalue" });
+            Assert.That(result.Csv,
+Is.EqualTo(@"ShouldStayNull;ShouldBeReplaced
+null;replacedvalue
+"));
+        }
 
+        [Test]
+        public void TestNoQuotesOption()
+        {
+            var json = @"[{
+""foo"" : "" Normally I would have quotes "",
+""bar"" : ""I would not""
+}]";
+            var result1 = Csv.Create(new CreateInput() { InputType = CreateInputType.Json, Delimiter = ";", Json = json }, new CreateOption() { NeverAddQuotesAroundValues = true });
+            Assert.That(result1.Csv,
+ Is.EqualTo(@"foo;bar
+ Normally I would have quotes ;I would not
+"));
+
+            var result2 = Csv.Create(new CreateInput() { InputType = CreateInputType.Json, Delimiter = ";", Json = json }, new CreateOption() { NeverAddQuotesAroundValues = false });
+            Assert.That(result2.Csv,
+ Is.EqualTo(@"foo;bar
+"" Normally I would have quotes "";I would not
+"));
+        }
+
+        [Test]
+        public void TestDatetimeValue()
+        {
+            var json = @"[{
+""datetime"" : ""2018-11-22T10:30:55"",
+""string"" : ""foo""
+}]";
+            var result = Csv.Create(new CreateInput() { InputType = CreateInputType.Json, Delimiter = ";", Json = json }, new CreateOption() { });
+            Assert.That(result.Csv,
+ Is.EqualTo(@"datetime;string
+2018-11-22T10:30:55;foo
+"));
+        }
+
+        [Test]
+        public void TestDecimalValues()
+        {
+            var json = @"[{
+""foo"" : 0.1,
+""bar"" : 1.00,
+""baz"" : 0.000000000000000000000000000000000000000000000000000000001
+}]";
+            var result = Csv.Create(new CreateInput() { InputType = CreateInputType.Json, Delimiter = ";", Json = json }, new CreateOption() { });
+            Assert.That(result.Csv,
+ Is.EqualTo(@"foo;bar;baz
+0.1;1.00;0.000000000000000000000000000000000000000000000000000000001
+"));
+        }
         [Test]
         [Ignore("Fails due to issue in CsvHelper #2")]
         public void ParseAndWriteShouldUseSeparateCultures()

--- a/Frends.Csv.Tests/packages.config
+++ b/Frends.Csv.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="2.16.3.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
 </packages>

--- a/Frends.Csv.Tests/packages.config
+++ b/Frends.Csv.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="2.16.3.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
 </packages>

--- a/Frends.Csv/Csv.cs
+++ b/Frends.Csv/Csv.cs
@@ -119,24 +119,25 @@ namespace Frends.Csv
             {
                 Delimiter = input.Delimiter,
                 HasHeaderRecord = option.IncludeHeaderRow,
-                CultureInfo = new CultureInfo(option.CultureInfo)
+                CultureInfo = new CultureInfo(option.CultureInfo),
+                QuoteNoFields = option.NeverAddQuotesAroundValues                                
             };
             var csv = "";
 
             switch (input.InputType)
             {
                 case CreateInputType.List:
-                    csv = ListToCsvString(input.Data, input.Headers, config);
+                    csv = ListToCsvString(input.Data, input.Headers, config, option);
                     break;
                 case CreateInputType.Json:
-                    csv = JsonToCsvString(input.Json, config);
+                    csv = JsonToCsvString(input.Json, config, option);
                     break;
             }
             return new CreateResult(csv);
 
         }
 
-        private static string ListToCsvString(List<List<object>> inputData, List<string> inputHeaders, CsvConfiguration config)
+        private static string ListToCsvString(List<List<object>> inputData, List<string> inputHeaders, CsvConfiguration config, CreateOption option)
         {
 
             using (var csvString = new StringWriter())
@@ -156,7 +157,7 @@ namespace Frends.Csv
                 {
                     foreach (var cell in row)
                     {
-                        csv.WriteField(cell);
+                        csv.WriteField(cell ?? option.ReplaceNullsWith);
                     }
                     csv.NextRecord();
                 }
@@ -165,9 +166,9 @@ namespace Frends.Csv
         }
 
 
-        private static string JsonToCsvString(string json, CsvConfiguration config)
+        private static string JsonToCsvString(string json, CsvConfiguration config, CreateOption option)
         {
-            var data = JsonConvert.DeserializeObject<List<Dictionary<string, object>>>(json);
+            List<Dictionary<string, string>> data = JsonConvert.DeserializeObject<List<Dictionary<string, string>>>(json);
 
             using (var csvString = new StringWriter())
             using (var csv = new CsvWriter(csvString, config))
@@ -186,7 +187,7 @@ namespace Frends.Csv
                 {
                     foreach (var cell in row)
                     {
-                        csv.WriteField(cell.Value);
+                        csv.WriteField(cell.Value ?? option.ReplaceNullsWith);
                     }
                     csv.NextRecord();
                 }

--- a/Frends.Csv/Definitions.cs
+++ b/Frends.Csv/Definitions.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Xml;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Formatting = Newtonsoft.Json.Formatting;
 
@@ -57,9 +58,21 @@ namespace Frends.Csv
         public bool IncludeHeaderRow { get; set; } = true;
 
         /// <summary>
-        /// Specify the culture info to be used with the parse. If this is left empty InvariantCulture will be used. List of cultures: https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx Use the Language Culture Name.
+        /// Specify the culture info to be used when creating csv. If this is left empty InvariantCulture will be used. List of cultures: https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx Use the Language Culture Name.
         /// </summary>
         public string CultureInfo { get; set; } = "";
+
+        /// <summary>
+        /// If set true csv's fields are never put in quotes
+        /// </summary>
+        [DefaultValue("false")]
+        public bool NeverAddQuotesAroundValues { get; set; }
+
+        /// <summary>
+        /// Input's null values will be replaced with this value
+        /// </summary>
+        [DisplayFormat(DataFormatString = "Text")]
+        public string ReplaceNullsWith { get; set; }
     }
 
     public class CreateResult

--- a/Frends.Csv/Frends.Csv.csproj
+++ b/Frends.Csv/Frends.Csv.csproj
@@ -35,8 +35,8 @@
     <Reference Include="CsvHelper, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\packages\CsvHelper.2.16.3.0\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Frends.Csv/Frends.Csv.csproj
+++ b/Frends.Csv/Frends.Csv.csproj
@@ -35,9 +35,8 @@
     <Reference Include="CsvHelper, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\packages\CsvHelper.2.16.3.0\lib\net45\CsvHelper.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Frends.Csv/packages.config
+++ b/Frends.Csv/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="2.16.3.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net452" />
 </packages>

--- a/Frends.Csv/packages.config
+++ b/Frends.Csv/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CsvHelper" version="2.16.3.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | ---------------------| ---------------------| ------------------------------------ |
 | IncludeHeaderRow     | bool                 | This flag tells the writer if a header row should be written. |  
 | CultureInfo          | string               | The culture info to write the file with, e.g. for decimal separators. InvariantCulture will be used by default. See list of cultures [here](https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx); use the Language Culture Name. <br> NOTE: Due to an issue with the CsvHelpers library, all CSV tasks will use the culture info setting of the first CSV task in the process; you cannot use different cultures for reading and parsing CSV files in the same process. |  
+| NeverAddQuotesAroundValues | bool           | If set true csv's fields are never put in quotes |  
+| ReplaceNullsWith     | string               | Input's null values will be replaced with this value |  
 
 #### Result
 

--- a/nuspec/Frends.Csv.nuspec
+++ b/nuspec/Frends.Csv.nuspec
@@ -10,7 +10,7 @@
     <description>FRENDS Csv tasks</description>
     <summary />
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="6.0.8" />
+      <dependency id="Newtonsoft.Json" version="12.0.1" />
       <dependency id="CsvHelper" version="[2.16.3.0]" />
     </dependencies>
     <frameworkAssemblies>
@@ -19,8 +19,8 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-	<file src="Frends.Csv\bin\Release\Frends.Csv.dll" target="lib\net452\Frends.Csv.dll" />
-    <file src="Frends.Csv\bin\Release\Frends.Csv.XML" target="Frends.Csv.XML"/>
-    <file src="Frends.Csv\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
+	<file src="..\Frends.Csv\bin\Release\Frends.Csv.dll" target="lib\net452\Frends.Csv.dll" />
+    <file src="..\Frends.Csv\bin\Release\Frends.Csv.XML" target="Frends.Csv.XML"/>
+    <file src="..\Frends.Csv\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
   </files>
 </package>

--- a/nuspec/Frends.Csv.nuspec
+++ b/nuspec/Frends.Csv.nuspec
@@ -19,8 +19,8 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-	<file src="..\Frends.Csv\bin\Release\Frends.Csv.dll" target="lib\net452\Frends.Csv.dll" />
-    <file src="..\Frends.Csv\bin\Release\Frends.Csv.XML" target="Frends.Csv.XML"/>
-    <file src="..\Frends.Csv\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
+	<file src="Frends.Csv\bin\Release\Frends.Csv.dll" target="lib\net452\Frends.Csv.dll" />
+    <file src="Frends.Csv\bin\Release\Frends.Csv.XML" target="Frends.Csv.XML"/>
+    <file src="Frends.Csv\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
   </files>
 </package>

--- a/nuspec/Frends.Csv.nuspec
+++ b/nuspec/Frends.Csv.nuspec
@@ -10,7 +10,7 @@
     <description>FRENDS Csv tasks</description>
     <summary />
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="12.0.1" />
+      <dependency id="Newtonsoft.Json" version="11.0.2" />
       <dependency id="CsvHelper" version="[2.16.3.0]" />
     </dependencies>
     <frameworkAssemblies>


### PR DESCRIPTION
Fixes for issue#8: 
When input is json, numbers and datetimes no longer get reformatted. 
2 new params for both input types: NeverAddQuotesAroundValues and ReplaceNullsWith

Other stuff:
Updated Newtonsoft.Json.6.0.8 to Newtonsoft.Json.12.0.1
Fixed nuspec source file paths