### PR TITLE
Bug fix issue #5

### DIFF
--- a/Frends.Csv.Tests/Tests.cs
+++ b/Frends.Csv.Tests/Tests.cs
@@ -311,7 +311,7 @@ year of the z;car;mark;price
                 ColumnSpecifications = new ColumnSpecification[0],
                 Delimiter = ";",
                 Csv = csv
-            }, new ParseOption() { ContainsHeaderRow = true, SkipRowsFromTop = 0, ReplaceHeaderWhiteSpaceWithString = "_" });
+            }, new ParseOption() { ContainsHeaderRow = true, SkipRowsFromTop = 0, ReplaceHeaderWhitespaceWith = "_" });
 
             dynamic resultJArray = result.ToJson();
             var resultXml = result.ToXml();

--- a/Frends.Csv.Tests/Tests.cs
+++ b/Frends.Csv.Tests/Tests.cs
@@ -86,7 +86,7 @@ year;car;mark;price
         public void TestParseWillAllKindOfDataTypes()
         {
             var csv =
-@"THIS;is;header;row;with;some;random;stuff;yes
+@"THIS;is;header;row;with;some;random;stuff ;yes
 1997;""Fo;rd"";2,34;true;1;4294967296;f;2008-09-15;2008-05-01 7:34:42Z
 2000;Mercury;2,38;false;0;4294967296;g;2009-09-15T06:30:41.7752486;Thu, 01 May 2008 07:34:42 GMT";
             var result = Csv.Parse(new ParseInput()
@@ -274,6 +274,56 @@ null;replacedvalue
 Foo;bar;100;1.1.2000 0.00.00
 "));
         }
+
+        [Test]
+        public void TestParseRowsWithAutomaticHeadersWhiteSpaceRemovalDefault()
+        {
+            var csv = $@"
+year of the z;car;mark;price 
+1997;Ford;E350;2,34
+2000;Mercury;Cougar;2,38";
+            var result = Csv.Parse(new ParseInput()
+            {
+                ColumnSpecifications = new ColumnSpecification[0],
+                Delimiter = ";",
+                Csv = csv
+            }, new ParseOption() { ContainsHeaderRow = true, SkipRowsFromTop = 0 });
+
+            dynamic resultJArray = result.ToJson();
+            var resultXml = result.ToXml();
+            var resultData = result.Data;
+            Assert.That(resultData.Count, Is.EqualTo(2));
+            Assert.That(resultJArray.Count, Is.EqualTo(2));
+            Assert.That(resultXml, Does.Contain("<yearofthez>"));
+            Assert.That(resultJArray[0].price.ToString(), Is.EqualTo("2,34"));
+        }
+
+
+        [Test]
+        public void TestParseRowsWithAutomaticHeadersWhiteSpaceRemovalGiven()
+        {
+            var csv = $@"
+year of the z;car;mark;price 
+1997;Ford;E350;2,34
+2000;Mercury;Cougar;2,38";
+            var result = Csv.Parse(new ParseInput()
+            {
+                ColumnSpecifications = new ColumnSpecification[0],
+                Delimiter = ";",
+                Csv = csv
+            }, new ParseOption() { ContainsHeaderRow = true, SkipRowsFromTop = 0, ReplaceHeaderWhiteSpaceWithString = "_" });
+
+            dynamic resultJArray = result.ToJson();
+            var resultXml = result.ToXml();
+            var resultData = result.Data;
+            Assert.That(resultData.Count, Is.EqualTo(2));
+            Assert.That(resultJArray.Count, Is.EqualTo(2));
+            Assert.That(resultXml, Does.Contain("<year_of_the_z>"));
+            Assert.That(resultJArray[0].price_.ToString(), Is.EqualTo("2,34"));
+        }
+
+
+
     }
 }
 

--- a/Frends.Csv/Csv.cs
+++ b/Frends.Csv/Csv.cs
@@ -14,6 +14,8 @@ namespace Frends.Csv
 {
     public class Csv
     {
+
+
         /// <summary>
         /// Parse string csv content to a object. See https://github.com/FrendsPlatform/Frends.Csv
         /// </summary>
@@ -70,7 +72,8 @@ namespace Frends.Csv
                     }
                     else if (option.ContainsHeaderRow && !input.ColumnSpecifications.Any())
                     {
-                        headers = csvReader.FieldHeaders.ToList();
+                        headers = csvReader.FieldHeaders.Select(x => x.Replace(" ", option.ReplaceHeaderWhiteSpaceWithString)).ToList();
+
                         while (csvReader.Read())
                         {
                             var innerList = new List<object>();

--- a/Frends.Csv/Csv.cs
+++ b/Frends.Csv/Csv.cs
@@ -72,7 +72,7 @@ namespace Frends.Csv
                     }
                     else if (option.ContainsHeaderRow && !input.ColumnSpecifications.Any())
                     {
-                        headers = csvReader.FieldHeaders.Select(x => x.Replace(" ", option.ReplaceHeaderWhiteSpaceWithString)).ToList();
+                        headers = csvReader.FieldHeaders.Select(x => x.Replace(" ", option.ReplaceHeaderWhitespaceWith)).ToList();
 
                         while (csvReader.Read())
                         {

--- a/Frends.Csv/Definitions.cs
+++ b/Frends.Csv/Definitions.cs
@@ -146,6 +146,12 @@ namespace Frends.Csv
         public bool TrimOutput { get; set; } = true;
 
         /// <summary>
+        /// If intended header value contains whitespaces replace it(them) with this string, default action is to remove them.
+        /// </summary>
+        [DefaultValue("String.Empty")]
+        public string ReplaceHeaderWhiteSpaceWithString { get; set; } = string.Empty;
+
+        /// <summary>
         /// The culture info to read/write the entries with, e.g. for decimal separators. InvariantCulture will be used by default. See list of cultures here: https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx; use the Language Culture Name.
         /// NOTE: Due to an issue with the CsvHelpers library, all CSV tasks will use the culture info setting of the first CSV task in the process; you cannot use different cultures for reading and parsing CSV files in the same process.|
         /// </summary>

--- a/Frends.Csv/Definitions.cs
+++ b/Frends.Csv/Definitions.cs
@@ -148,8 +148,8 @@ namespace Frends.Csv
         /// <summary>
         /// If intended header value contains whitespaces replace it(them) with this string, default action is to remove them.
         /// </summary>
-        [DefaultValue("String.Empty")]
-        public string ReplaceHeaderWhiteSpaceWithString { get; set; } = string.Empty;
+        [DisplayFormat(DataFormatString = "Text")]
+        public string ReplaceHeaderWhitespaceWith { get; set; } = string.Empty;
 
         /// <summary>
         /// The culture info to read/write the entries with, e.g. for decimal separators. InvariantCulture will be used by default. See list of cultures here: https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx; use the Language Culture Name.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | SkipRowsFromTop      | int                  | This value is set to ignore a specific amount of rows from the beginning of the csv string. This can for example be used if the string contains some metadata on the first row before the header.  |  
 | SkipEmptyRows        | bool                 | A flag to let the reader know if a record should be skipped when reading if it's empty. A record is considered empty if all fields are empty.                |  
 | TrimOutput           | bool                 | This flag tells the reader to trim whitespace from the beginning and ending of the field value when reading.              |  
-| ReplaceHeaderWhiteSpaceWithString  | string | This flag tells the reader to replace possible whitespace in the header field with specific string. Default is empty string. | 
+| ReplaceHeaderWhiteSpaceWith  | string       | This flag tells the reader to replace possible whitespace in the header field with specific string. Default is empty string. | 
 | CultureInfo          | string               | The culture info to parse the file with, e.g. for decimal separators. InvariantCulture will be used by default. See list of cultures [here](https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx); use the Language Culture Name. <br> NOTE: Due to an issue with the CsvHelpers library, all CSV tasks will use the culture info setting of the first CSV task in the process; you cannot use different cultures for reading and parsing CSV files in the same process.|  
 
 #### Example usage

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | SkipRowsFromTop      | int                  | This value is set to ignore a specific amount of rows from the beginning of the csv string. This can for example be used if the string contains some metadata on the first row before the header.  |  
 | SkipEmptyRows        | bool                 | A flag to let the reader know if a record should be skipped when reading if it's empty. A record is considered empty if all fields are empty.                |  
 | TrimOutput           | bool                 | This flag tells the reader to trim whitespace from the beginning and ending of the field value when reading.              |  
+| ReplaceHeaderWhiteSpaceWithString  | string | This flag tells the reader to replace possible whitespace in the header field with specific string. Default is empty string. | 
 | CultureInfo          | string               | The culture info to parse the file with, e.g. for decimal separators. InvariantCulture will be used by default. See list of cultures [here](https://msdn.microsoft.com/en-us/library/ee825488(v=cs.20).aspx); use the Language Culture Name. <br> NOTE: Due to an issue with the CsvHelpers library, all CSV tasks will use the culture info setting of the first CSV task in the process; you cannot use different cultures for reading and parsing CSV files in the same process.|  
 
 #### Example usage

--- a/nuspec/Frends.Csv.nuspec
+++ b/nuspec/Frends.Csv.nuspec
@@ -1,26 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
+<?xml version="1.0"?>
+<package >
   <metadata>
     <id>Frends.Csv</id>
-    <version>1.0.0.0</version>
-    <title>FRENDS Csv tasks</title>
-    <authors>HiQ Finland</authors>
-    <owners />
+    <version>1.0.0</version>
+    <authors>HiqFinland</authors>
+    <owners>HiqFinland</owners>  
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>FRENDS Csv tasks</description>
-    <summary />
+    <description>Frends CSV parser</description>
+    <releaseNotes>Added whitespaceremoval option for header values.</releaseNotes>
+    <copyright>Copyright 2019</copyright>    
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="11.0.2" />
-      <dependency id="CsvHelper" version="[2.16.3.0]" />
+      <dependency id="SampleDependency" version="1.0" />
     </dependencies>
-    <frameworkAssemblies>
-      <frameworkAssembly assemblyName="System" />
-      <frameworkAssembly assemblyName="System.Data" />
-    </frameworkAssemblies>
   </metadata>
-  <files>
-	<file src="Frends.Csv\bin\Release\Frends.Csv.dll" target="lib\net452\Frends.Csv.dll" />
-    <file src="Frends.Csv\bin\Release\Frends.Csv.XML" target="Frends.Csv.XML"/>
-    <file src="Frends.Csv\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
-  </files>
 </package>

--- a/nuspec/Frends.Csv.nuspec
+++ b/nuspec/Frends.Csv.nuspec
@@ -1,16 +1,26 @@
-<?xml version="1.0"?>
-<package >
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>Frends.Csv</id>
-    <version>1.0.0</version>
-    <authors>HiqFinland</authors>
-    <owners>HiqFinland</owners>  
+    <version>1.0.0.0</version>
+    <title>FRENDS Csv tasks</title>
+    <authors>HiQ Finland</authors>
+    <owners />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Frends CSV parser</description>
-    <releaseNotes>Added whitespaceremoval option for header values.</releaseNotes>
-    <copyright>Copyright 2019</copyright>    
+    <description>FRENDS Csv tasks</description>
+    <summary />
     <dependencies>
-      <dependency id="SampleDependency" version="1.0" />
+      <dependency id="Newtonsoft.Json" version="11.0.2" />
+      <dependency id="CsvHelper" version="[2.16.3.0]" />
     </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System" />
+      <frameworkAssembly assemblyName="System.Data" />
+    </frameworkAssemblies>
   </metadata>
+  <files>
+	<file src="Frends.Csv\bin\Release\Frends.Csv.dll" target="lib\net452\Frends.Csv.dll" />
+    <file src="Frends.Csv\bin\Release\Frends.Csv.XML" target="Frends.Csv.XML"/>
+    <file src="Frends.Csv\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
+  </files>
 </package>


### PR DESCRIPTION
fix the issue when creating automated header tags from CSV.  Xml might become invalid if intended header field had whitespaces on it,
by adding optional ReplaceHeaderWhiteSpaceWithString field on Parse options, default is empty string.
e.g. CSV header field A_B C becomes <A_BC> with default settings 