### PR TITLE
Change Parse function to handle any whitespace characters

### DIFF
--- a/Frends.Csv.Tests/Tests.cs
+++ b/Frends.Csv.Tests/Tests.cs
@@ -329,6 +329,32 @@ year of the z;car;mark;price
             Assert.That(resultJArray[0].price.ToString(), Is.EqualTo("2,34"));
         }
 
+        [Test]
+        public void TestParseRowsWithAutomaticHeadersDifferentWhiteSpacesRemoval()
+        {
+            var csv = $@"
+hair space;six-per-em space;thin space;punctuation space;four-per-em space;three-per-em space;figure space;en space;em space
+test;test;test;test;test;test;test;test;test;
+";
+            var result = Csv.Parse(new ParseInput()
+            {
+                ColumnSpecifications = new ColumnSpecification[0],
+                Delimiter = ";",
+                Csv = csv
+            }, new ParseOption() { ContainsHeaderRow = true, SkipRowsFromTop = 0 });
+
+            var resultXml = result.ToXml();
+            Assert.That(resultXml, Does.Contain("hair space"));
+            Assert.That(resultXml, Does.Contain("six-per-em space"));
+            Assert.That(resultXml, Does.Contain("thin space"));
+            Assert.That(resultXml, Does.Contain("punctuation space"));
+            Assert.That(resultXml, Does.Contain("four-per-em space"));
+            Assert.That(resultXml, Does.Contain("three-per-em space"));
+            Assert.That(resultXml, Does.Contain("figure space"));
+            Assert.That(resultXml, Does.Contain("en space"));
+            Assert.That(resultXml, Does.Contain("em space"));
+        }
+
 
 
     }

--- a/Frends.Csv/Csv.cs
+++ b/Frends.Csv/Csv.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using CsvHelper;
 using CsvHelper.Configuration;
 using Newtonsoft.Json;
@@ -79,16 +80,9 @@ namespace Frends.Csv
                     }
                     else if (option.ContainsHeaderRow && !input.ColumnSpecifications.Any())
                     {
-                        if (string.Equals(option.ReplaceHeaderWhitespaceWith, " "))
-                        {
-                            headers = csvReader.Context.HeaderRecord.ToList();
-                        }
-                        else
-                        {
-                            headers = csvReader.Context.HeaderRecord.Select(x => x.Replace(" ", option.ReplaceHeaderWhitespaceWith)).ToList();
-                        }
+                        var replacementString = string.IsNullOrEmpty(option.ReplaceHeaderWhitespaceWith) ? " " : option.ReplaceHeaderWhitespaceWith;
 
-                       
+                        headers = csvReader.Context.HeaderRecord.Select(x => Regex.Replace(x, @"\s", replacementString)).ToList();
 
                         while (csvReader.Read())
                         {


### PR DESCRIPTION
Instead of just spaces, this PR changes the behavior of the Parse function to use regex to find and replace all whitespace characters to space or a string determined in the options.